### PR TITLE
Add automation to build/publish

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,0 +1,23 @@
+workflow "Release" {
+  on = "push"
+  resolves = ["goreleaser"]
+}
+
+action "is-tag" {
+  uses = "actions/bin/filter@master"
+  args = "tag"
+}
+
+action "goreleaser" {
+  uses = "docker://goreleaser/goreleaser"
+  secrets = [
+    "GITHUB_TOKEN",
+
+    # at least GITHUB_TOKEN is required, you may need more though
+    "DOCKER_USERNAME",
+
+    "DOCKER_PASSWORD",
+  ]
+  args = "release"
+  needs = ["is-tag"]
+}

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -12,11 +12,6 @@ action "goreleaser" {
   uses = "docker://goreleaser/goreleaser"
   secrets = [
     "GITHUB_TOKEN",
-
-    # at least GITHUB_TOKEN is required, you may need more though
-    "DOCKER_USERNAME",
-
-    "DOCKER_PASSWORD",
   ]
   args = "release"
   needs = ["is-tag"]

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+dist
+release

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,29 @@
+before:
+  hooks:
+    - go mod download
+builds:
+- env:
+  - CGO_ENABLED=0
+  ignore:
+    - goos: darwin
+      goarch: 386
+    - goos: linux
+      goarch: arm
+      goarm: 7
+archive:
+  replacements:
+    darwin: Darwin
+    linux: Linux
+    windows: Windows
+    386: i386
+    amd64: x86_64
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ .Tag }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+    - '^docs:'
+    - '^test:'

--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/lizrice/kubectl-who-can/cmd"
+	"github.com/aquasecurity/kubectl-who-can/cmd"
 )
 
 func main() {


### PR DESCRIPTION
Publish binaries to a github release on tag events. To use: create a tag and the github action will build and publish binaries to a release, as well as create a simple changelog of commits since the last release.

_Uses github actions and goreleaser_

See https://github.com/gabeduke/kubectl-who-can/releases/tag/0.0.3 for an example of the published artifacts on a tagged release.