### PR TITLE
Integrate with TravisCI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,7 @@ dist
 release
 kubectl-who-can
 
+coverage.txt
+
 # GoLand / IntelliJ IDEA project config files
 .idea/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: go
+
+env:
+  - GO111MODULE=on
+
+go:
+  - 1.12.x
+
+git:
+  depth: 1
+
+notifications:
+  email: false
+
+script:
+  - go test -v -race -coverprofile=coverage.txt -covermode=atomic ./...
+  - go build -o kubectl-who-can main.go
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Build Status](https://travis-ci.org/aquasecurity/kubectl-who-can.svg?branch=master)](https://travis-ci.org/aquasecurity/kubectl-who-can)
+[![codecov.io](https://codecov.io/github/aquasecurity/kubectl-who-can/branch/master/graph/badge.svg)](https://codecov.io/github/aquasecurity/kubectl-who-can)
+
 # kubectl-who-can
 [WIP] show who has permissions to &lt;verb> &lt;resources> in kubernetes
 


### PR DESCRIPTION
This one partially resolves #9 . Currently the Travis CI just runs tests, builds executable, and upload the coverage report to https://codecov.io.

I'll submit a separate PR for integrating with https://goreleaser.com/