### PR TITLE
Configure GoReleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,21 +2,27 @@ before:
   hooks:
     - go mod download
 builds:
-- env:
-  - CGO_ENABLED=0
-  ignore:
-    - goos: darwin
-      goarch: 386
-    - goos: linux
-      goarch: arm
-      goarm: 7
-archive:
-  replacements:
-    darwin: Darwin
-    linux: Linux
-    windows: Windows
-    386: i386
-    amd64: x86_64
+  - # Path to main.go file or main package.
+    main: ./main.go
+    # Custom environment variables to be set during the builds.
+    env:
+      - CGO_ENABLED=0
+    # GOOS list to build for.
+    goos:
+      - darwin
+      - linux
+      - windows
+    # GOARCH to build for.
+    goarch:
+      - amd64
+archives:
+  - # Archive name template
+    name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
+    replacements:
+      amd64: x86_64
+    format_overrides:
+      - goos: windows
+        format: zip
 checksum:
   name_template: 'checksums.txt'
 snapshot:
@@ -25,5 +31,6 @@ changelog:
   sort: asc
   filters:
     exclude:
-    - '^docs:'
-    - '^test:'
+      - '^docs:'
+      - '^test:'
+      - '^chore:'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,24 @@
 language: go
-
 env:
-  - GO111MODULE=on
-
+  matrix:
+    - GO111MODULE=on
+  global:
+    secure: utJI+HwXlw0hW28cydKdHLc5CRM8xoal9YGbo0hkHTgiiRcJuavT55/wwJQ6tSvrrEjMwD3g5aSzS1UifhYx+XwMvishJ7gGa1vFU7yz80YPPoEJzMKEHIkW9Eac8f8QnBgl4yNm8tdijUaj851DCJ8dg7WHUMAKAEY9/gYOi4f6hzXI4abHHx30ppbGqM3/qnst83b8i95nTC3c8X0MYRW9TH93iQBORDbj9XQKFQBiIbpQ/sm5iBQgIdKDsPcNaRzvMxwJk2tVb5DrlnMbxIfvBc8axbTvIdvHgRjZEMykooMhC6M24yJO7f9BEy86zkcgL+TyMQ6U7kf183xM/C3Jrcdn49GX+lyJcOOHjUmkDCgQgxF/YYML8uytXrfd3Ghsf4ap+Xnm6UxXz9OF3FDkLdGzgExr3HwZ8PTESNt80TEWJWI/vtIndId0Ad32mXp/FX5iIsQPe343U8xXPM/z+/pWsS4clCQDC9MXaIK1i4ZVfchTz7dyVHeQJMYZzSbILNPQrgkY9moZA/ilsBMMOT5myjEqq++1ktOlnBK9Gyue5Xt7XyAgAJlHTDIm8PQVwEadCIr/XJcLGptTmPSNOjft91jobnwlxlnfRK+m/KsUI6FY6ZNBGiQ8oVVPk6pCSghBxViQndqCO8vH3zjbRRQmE6SDrrpbnE2kpTE=
 go:
   - 1.12.x
-
 git:
   depth: 1
-
 notifications:
   email: false
-
 script:
   - go test -v -race -coverprofile=coverage.txt -covermode=atomic ./...
   - go build -o kubectl-who-can main.go
-
 after_success:
   - bash <(curl -s https://codecov.io/bash)
+deploy:
+  - provider: script
+    skip_cleanup: true
+    script: curl -sL https://git.io/goreleaser | bash
+    on:
+      tags: true
+      condition: "$TRAVIS_OS_NAME = linux"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
-[![Build Status](https://travis-ci.org/aquasecurity/kubectl-who-can.svg?branch=master)](https://travis-ci.org/aquasecurity/kubectl-who-can)
-[![codecov.io](https://codecov.io/github/aquasecurity/kubectl-who-can/branch/master/graph/badge.svg)](https://codecov.io/github/aquasecurity/kubectl-who-can)
+[![GitHub release][release-img]][release]
+[![Build Status][ci-img]][ci]
+[![Coverage Status][cov-img]][cov]
+[![Go Report Card][report-card-img]][report-card]
 
 # kubectl-who-can
 [WIP] show who has permissions to &lt;verb> &lt;resources> in kubernetes
@@ -40,3 +42,15 @@ The `kubectl-who-can` binary will be in `/usr/local/bin`.
 
 * Make it a kubectl plugin (for now it's a standalone executable)
 * Alert if user doesn't have access to all namespaces, roles, clusterroles or bindings (as info won't be complete)
+
+[release-img]: https://img.shields.io/github/release/aquasecurity/kubectl-who-can.svg
+[release]: https://github.com/aquasecurity/kubectl-who-can/releases
+
+[ci-img]: https://travis-ci.org/aquasecurity/kubectl-who-can.svg?branch=master
+[ci]: https://travis-ci.org/aquasecurity/kubectl-who-can
+
+[cov-img]: https://codecov.io/github/aquasecurity/kubectl-who-can/branch/master/graph/badge.svg
+[cov]: https://codecov.io/github/aquasecurity/kubectl-who-can
+
+[report-card-img]: https://goreportcard.com/badge/github.com/aquasecurity/kubectl-who-can
+[report-card]: https://goreportcard.com/report/github.com/aquasecurity/kubectl-who-can


### PR DESCRIPTION
This one should allow us to release archives including executables for Linux, macOS, and Window.

# Test release locally:

```
$ brew install goreleaser/tap/goreleaser
$ goreleaser --snapshot --skip-publish --rm-dist
```

If everything is fine check the content of the `./dist` directory.

```
$ ls -1 ./dist
checksums.txt
config.yaml
darwin_amd64
kubectl-who-can_darwin_x86_64
kubectl-who-can_darwin_x86_64.tar.gz
kubectl-who-can_linux_x86_64
kubectl-who-can_linux_x86_64.tar.gz
kubectl-who-can_windows_x86_64
kubectl-who-can_windows_x86_64.zip
linux_amd64
windows_amd64
```

# Do the actual release:

```
$ git tag -a v0.1.0-alpha.1 -m "First release"
$ git push origin v0.1.0-alpha.1
```

After that TravisCI will trigger a build. On successful build the deploy step will run the `goreleaser` at the root of the repository and publish release artifacts to GitHub releases.

> NB We need to define the `GITHUB_TOKEN` (encrypted) environment variable in TravisCI, which should contain a valid GitHub token with the repo scope.
>
> For example, to add the encrypted env go to project root and execute the following commands:
> ```
> gem install travis
> travis encrypt GITHUB_TOKEN=$TOKEN --add env.global
> git add .travis.yml && git commit -m 'chore: Add GitHub access token'