### PR TITLE
feat: Validate verb and resource passed as CLI args

### DIFF
--- a/pkg/cmd/whocan/access_checker.go
+++ b/pkg/cmd/whocan/access_checker.go
@@ -1,4 +1,4 @@
-package cmd
+package whocan
 
 import (
 	authzv1 "k8s.io/api/authorization/v1"

--- a/pkg/cmd/whocan/access_checker_test.go
+++ b/pkg/cmd/whocan/access_checker_test.go
@@ -1,4 +1,4 @@
-package cmd
+package whocan
 
 import (
 	"errors"
@@ -14,31 +14,31 @@ import (
 func TestIsAllowed(t *testing.T) {
 
 	data := []struct {
-		name         string
+		scenario     string
 		reactionFunc k8stesting.ReactionFunc
 
 		allowed bool
 		err     error
 	}{
 		{
-			name:         "Should return true when SSAR's allowed property is true",
+			scenario:     "Should return true when SSAR's allowed property is true",
 			reactionFunc: newSelfSubjectAccessReviewsReactionFunc(true, nil),
 			allowed:      true,
 		},
 		{
-			name:         "Should return false when SSAR's allowed property is false",
+			scenario:     "Should return false when SSAR's allowed property is false",
 			reactionFunc: newSelfSubjectAccessReviewsReactionFunc(false, nil),
 			allowed:      false,
 		},
 		{
-			name:         "Should return error when API request fails",
+			scenario:     "Should return error when API request fails",
 			reactionFunc: newSelfSubjectAccessReviewsReactionFunc(false, errors.New("api is down")),
 			err:          errors.New("api is down"),
 		},
 	}
 
 	for _, tt := range data {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.scenario, func(t *testing.T) {
 			// given
 			client := newClient(tt.reactionFunc)
 

--- a/pkg/cmd/whocan/namespace_validator.go
+++ b/pkg/cmd/whocan/namespace_validator.go
@@ -1,0 +1,40 @@
+package whocan
+
+import (
+	"fmt"
+	apicorev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+type NamespaceValidator interface {
+	Validate(name string) error
+}
+
+type namespaceValidator struct {
+	client typedcorev1.NamespaceInterface
+}
+
+func NewNamespaceValidator(client typedcorev1.NamespaceInterface) NamespaceValidator {
+	return &namespaceValidator{
+		client: client,
+	}
+}
+
+func (w *namespaceValidator) Validate(name string) error {
+	if name != apicorev1.NamespaceAll {
+		ns, err := w.client.Get(name, metav1.GetOptions{})
+		if err != nil {
+			if statusErr, ok := err.(*errors.StatusError); ok &&
+				statusErr.Status().Reason == metav1.StatusReasonNotFound {
+				return fmt.Errorf("\"%s\" not found", name)
+			}
+			return fmt.Errorf("getting namespace: %v", err)
+		}
+		if ns.Status.Phase != apicorev1.NamespaceActive {
+			return fmt.Errorf("invalid status: %v", ns.Status.Phase)
+		}
+	}
+	return nil
+}

--- a/pkg/cmd/whocan/namespace_validator_test.go
+++ b/pkg/cmd/whocan/namespace_validator_test.go
@@ -1,0 +1,95 @@
+package whocan
+
+import (
+	"errors"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	v12 "k8s.io/client-go/kubernetes/typed/core/v1"
+	k8stesting "k8s.io/client-go/testing"
+	"testing"
+)
+
+func TestNamespaceValidator_Validate(t *testing.T) {
+
+	data := []struct {
+		TestName string
+
+		APIReturnedNamespace *v1.Namespace
+		APIReturnedErr       error
+
+		ExpectedErr error
+	}{
+		{
+			TestName: "Should return error when getting namespace fails",
+
+			APIReturnedNamespace: nil,
+			APIReturnedErr:       errors.New("server is down"),
+
+			ExpectedErr: errors.New("getting namespace: server is down"),
+		}, {
+			TestName: "Should return error when namespace does not exist",
+
+			APIReturnedNamespace: nil,
+			APIReturnedErr: &k8serrors.StatusError{
+				ErrStatus: metav1.Status{
+					Reason: metav1.StatusReasonNotFound,
+				},
+			},
+
+			ExpectedErr: errors.New("\"my.namespace\" not found"),
+		}, {
+			TestName: "Should return error when namespace is not active",
+
+			APIReturnedNamespace: &v1.Namespace{
+				Status: v1.NamespaceStatus{
+					Phase: v1.NamespaceTerminating,
+				},
+			},
+			APIReturnedErr: nil,
+
+			ExpectedErr: errors.New("invalid status: Terminating"),
+		}, {
+			TestName: "Should return nil when namespace is active",
+
+			APIReturnedNamespace: &v1.Namespace{
+				Status: v1.NamespaceStatus{
+					Phase: v1.NamespaceActive,
+				},
+			},
+			APIReturnedErr: nil,
+
+			ExpectedErr: nil,
+		},
+	}
+
+	for _, tt := range data {
+		t.Run(tt.TestName, func(t *testing.T) {
+			// given
+			namespace := newNamespaces(newGetNamespacesReactionFunc(tt.APIReturnedNamespace, tt.APIReturnedErr))
+			validator := NewNamespaceValidator(namespace)
+
+			// when
+			err := validator.Validate("my.namespace")
+
+			// then
+			assert.Equal(t, tt.ExpectedErr, err)
+		})
+	}
+
+}
+
+func newNamespaces(reaction k8stesting.ReactionFunc) v12.NamespaceInterface {
+	client := fake.NewSimpleClientset()
+	client.Fake.PrependReactor("get", "namespaces", reaction)
+	return client.CoreV1().Namespaces()
+}
+
+func newGetNamespacesReactionFunc(ns *v1.Namespace, err error) k8stesting.ReactionFunc {
+	return func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, ns, err
+	}
+}

--- a/pkg/cmd/whocan/resource_resolver.go
+++ b/pkg/cmd/whocan/resource_resolver.go
@@ -1,0 +1,110 @@
+package whocan
+
+import (
+	"fmt"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/restmapper"
+)
+
+// ResourceResolver wraps the Resolve method.
+//
+// Resolve attempts to resolve a APIResource by `resourceArg` and validate that the specified `verbArg` is supported.
+type ResourceResolver interface {
+	Resolve(verbArg, resourceArg string) (v1.APIResource, error)
+}
+
+type resourceResolver struct {
+	client discovery.DiscoveryInterface
+}
+
+func NewResourceResolver(client discovery.DiscoveryInterface) ResourceResolver {
+	return &resourceResolver{
+		client: client,
+	}
+}
+
+func (rv *resourceResolver) Resolve(verbArg, resourceArg string) (v1.APIResource, error) {
+	resource, err := rv.resourceFor(resourceArg)
+	if err != nil {
+		return v1.APIResource{}, fmt.Errorf("resolving resource: %v", err)
+	}
+
+	if resource.Name == "" {
+		return v1.APIResource{}, fmt.Errorf("the server doesn't have a resource type \"%s\"", resourceArg)
+	}
+
+	if !rv.isVerbSupportedBy(verbArg, resource) {
+		return v1.APIResource{}, fmt.Errorf("the \"%s\" resource does not support the \"%s\" verb, only %v", resourceArg, verbArg, resource.Verbs)
+	}
+
+	return resource, nil
+}
+
+func (rv *resourceResolver) resourceFor(resourceArg string) (v1.APIResource, error) {
+	index, err := rv.indexResources()
+	if err != nil {
+		return v1.APIResource{}, err
+	}
+
+	resource, ok := index[resourceArg]
+	if ok {
+		return resource, nil
+	}
+
+	groupResources, err := restmapper.GetAPIGroupResources(rv.client)
+	if err != nil {
+		return v1.APIResource{}, err
+	}
+
+	mapper := restmapper.NewDiscoveryRESTMapper(groupResources)
+	gvr, err := mapper.ResourceFor(schema.GroupVersionResource{Resource: resourceArg})
+	if err != nil {
+		return v1.APIResource{}, nil
+	}
+	return index[gvr.Resource], nil
+}
+
+// indexResources builds a lookup index for APIResources where the keys are resources names (both plural and short names).
+func (rv *resourceResolver) indexResources() (map[string]v1.APIResource, error) {
+	serverResources := make(map[string]v1.APIResource)
+
+	serverGroups, err := rv.client.ServerGroups()
+	if err != nil {
+		return nil, fmt.Errorf("getting API groups: %v", err)
+	}
+	for _, sg := range serverGroups.Groups {
+		for _, version := range sg.Versions {
+			// Consider only preferred versions
+			if version.GroupVersion != sg.PreferredVersion.GroupVersion {
+				continue
+			}
+			rsList, err := rv.client.ServerResourcesForGroupVersion(version.GroupVersion)
+			if err != nil {
+				return nil, fmt.Errorf("getting resources for API group: %v", err)
+			}
+
+			for _, res := range rsList.APIResources {
+				serverResources[res.Name] = res
+				if len(res.ShortNames) > 0 {
+					for _, sn := range res.ShortNames {
+						serverResources[sn] = res
+					}
+				}
+			}
+		}
+	}
+	return serverResources, nil
+}
+
+// isVerbSupportedBy returns `true` if the given verbArg is supported by the given resourceArg, `false` otherwise.
+func (rv *resourceResolver) isVerbSupportedBy(verb string, resource v1.APIResource) bool {
+	supported := false
+	for _, v := range resource.Verbs {
+		if v == verb {
+			supported = true
+		}
+	}
+	return supported
+}

--- a/pkg/cmd/whocan/resource_resolver_test.go
+++ b/pkg/cmd/whocan/resource_resolver_test.go
@@ -1,0 +1,57 @@
+package whocan
+
+import (
+	"errors"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	"testing"
+)
+
+func TestResourceResolver_Resolve(t *testing.T) {
+
+	client := fake.NewSimpleClientset()
+
+	client.Resources = []*v1.APIResourceList{
+		{
+			GroupVersion: "v1",
+			APIResources: []v1.APIResource{
+				{Name: "pods", ShortNames: []string{"po"}, Verbs: []string{"list", "create", "delete"}},
+				{Name: "services", ShortNames: []string{"svc"}, Verbs: []string{"list", "delete"}},
+			},
+		},
+	}
+
+	data := []struct {
+		name        string
+		verbArg     string
+		resourceArg string
+
+		expectedResourceName string
+		expectedErr          error
+	}{
+		{name: "s1", verbArg: "list", resourceArg: "pods",
+			expectedResourceName: "pods"},
+		{name: "s2", verbArg: "list", resourceArg: "po",
+			expectedResourceName: "pods"},
+		{name: "s3", verbArg: "eat", resourceArg: "pods",
+			expectedResourceName: "", expectedErr: errors.New("the \"pods\" resource does not support the \"eat\" verb, only [list create delete]")},
+		{name: "s4", verbArg: "list", resourceArg: "services",
+			expectedResourceName: "services"},
+		{name: "s5", verbArg: "list", resourceArg: "svc",
+			expectedResourceName: "services"},
+		{name: "s6", verbArg: "mow", resourceArg: "services",
+			expectedResourceName: "", expectedErr: errors.New("the \"services\" resource does not support the \"mow\" verb, only [list delete]")},
+	}
+
+	resolver := NewResourceResolver(client.Discovery())
+
+	for _, tt := range data {
+		t.Run(tt.name, func(t *testing.T) {
+			resource, err := resolver.Resolve(tt.verbArg, tt.resourceArg)
+
+			assert.Equal(t, tt.expectedErr, err)
+			assert.Equal(t, resource.Name, tt.expectedResourceName)
+		})
+	}
+}


### PR DESCRIPTION
Resolves #18 

Example args:

```
$./kubectl-who-can get pods
$./kubectl-who-can get pod
$./kubectl-who-can get po
$./kubectl-who-can create cm
```

Example validation errors:

```
$./kubectl-who-can eat pods
Error: resolving resource: the "pods" resource does not support the "eat" verb, only [create delete deletecollection get list patch update watch]
$ ./kubectl-who-can list frogs
Error: resolving resource: the server doesn't have a resource type "frogs"
$./kubectl-who-can eat po
Error: resolving resource: the "po" resource does not support the "eat" verb, only [create delete deletecollection get list patch update watch]
```