### PR TITLE
test: Add Kubernetes integration test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ coverage.txt
 
 # GoLand / IntelliJ IDEA project config files
 .idea/
+
+# Kubernetes integration test binary
+test/bin/integration_test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: go
+services:
+  - docker
 env:
   matrix:
     - GO111MODULE=on
@@ -12,6 +14,7 @@ notifications:
   email: false
 script:
   - make tests
+  - make integration-tests
   - make
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/makefile
+++ b/makefile
@@ -8,3 +8,8 @@ $(BINARY): $(SOURCES)
 
 tests: $(SOURCES)
 	GO111MODULE=on go test -v -short -race -timeout 30s -coverprofile=coverage.txt -covermode=atomic ./...
+
+integration-tests: $(SOURCES)
+	GO111MODULE=on GOOS=linux CGO_ENABLED=0 go test -v -c -o test/bin/integration_test test/integration_test.go
+	@docker-compose -f test/docker-compose.yaml build --no-cache --force-rm
+	@docker-compose -f test/docker-compose.yaml up --abort-on-container-exit --exit-code-from test

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,0 +1,5 @@
+FROM scratch
+
+COPY bin/integration_test /integration_test
+
+ENTRYPOINT ["/integration_test", "-test.v"]

--- a/test/docker-compose.yaml
+++ b/test/docker-compose.yaml
@@ -1,0 +1,28 @@
+version: '3'
+services:
+  kube:
+    network_mode: host
+    image: rancher/k3s:v0.5.0
+    command: server --disable-agent
+    ports:
+      - 6443:6443
+    environment:
+      - K3S_CLUSTER_SECRET=somethingtotallyrandom
+      - K3S_KUBECONFIG_OUTPUT=/output/kubeconfig.yaml
+      - K3S_KUBECONFIG_MODE=666
+    volumes:
+      - kube-data:/var/lib/rancher/k3s
+      - kube-data:/tmp
+      - shared-data:/output
+  test:
+    network_mode: host
+    build: .
+    environment:
+      - KUBECONFIG=/output/kubeconfig.yaml
+    volumes:
+      - shared-data:/output
+    depends_on:
+      - kube
+volumes:
+  kube-data:
+  shared-data:

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -1,0 +1,108 @@
+package test
+
+import (
+	"github.com/aquasecurity/kubectl-who-can/pkg/cmd"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	rbac "k8s.io/api/rbac/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Integration test")
+	}
+
+	// TODO Wait for KUBECONFIG
+	time.Sleep(10 * time.Second)
+
+	config, err := clientcmd.BuildConfigFromFlags("", os.Getenv("KUBECONFIG"))
+	require.NoError(t, err)
+
+	kubeClient, err := kubernetes.NewForConfig(config)
+	require.NoError(t, err)
+
+	clientRBAC := kubeClient.RbacV1()
+
+	_, err = clientRBAC.Roles("default").Create(&rbac.Role{
+		ObjectMeta: meta.ObjectMeta{Name: "create-configmaps"},
+		Rules: []rbac.PolicyRule{
+			{
+				APIGroups: []string{"v1"},
+				Verbs:     []string{"create"},
+				Resources: []string{"configmaps"},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = clientRBAC.RoleBindings("default").Create(&rbac.RoleBinding{
+		ObjectMeta: meta.ObjectMeta{Name: "alice-can-create-configmaps"},
+		RoleRef:    rbac.RoleRef{Name: "create-configmaps", Kind: "Role"},
+		Subjects: []rbac.Subject{
+			{Name: "Alice", Kind: "User"},
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = clientRBAC.ClusterRoles().Create(&rbac.ClusterRole{
+		ObjectMeta: meta.ObjectMeta{Name: "get-logs"},
+		Rules: []rbac.PolicyRule{
+			{
+				Verbs:           []string{"get"},
+				NonResourceURLs: []string{"/logs"},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = clientRBAC.ClusterRoleBindings().Create(&rbac.ClusterRoleBinding{
+		ObjectMeta: meta.ObjectMeta{Name: "bob-can-get-logs"},
+		RoleRef:    rbac.RoleRef{Name: "get-logs", Kind: "ClusterRole"},
+		Subjects: []rbac.Subject{
+			{Name: "Bob", Kind: "User"},
+		},
+	})
+	require.NoError(t, err)
+
+	data := []struct {
+		scenario string
+		args     []string
+		output   string
+	}{
+		{
+			scenario: "Should print who can crete configmaps",
+			args:     []string{"create", "cm"},
+			output: `ROLEBINDING                  NAMESPACE  SUBJECT  TYPE  SA-NAMESPACE
+alice-can-create-configmaps  default    Alice    User`,
+		},
+		{
+			scenario: "Should print who can get /healthz",
+			args:     []string{"get", "/logs"},
+			output: `CLUSTERROLEBINDING  SUBJECT  TYPE  SA-NAMESPACE
+bob-can-get-logs    Bob      User`,
+		},
+	}
+	for _, tt := range data {
+		t.Run(tt.scenario, func(t *testing.T) {
+			streams, _, out, _ := genericclioptions.NewTestIOStreams()
+			root, err := cmd.NewCmdWhoCan(streams)
+			require.NoError(t, err)
+
+			root.SetArgs(tt.args)
+
+			err = root.Execute()
+			require.NoError(t, err)
+
+			t.Log(out.String())
+			assert.Contains(t, out.String(), tt.output)
+		})
+	}
+
+}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -77,7 +77,7 @@ func TestIntegration(t *testing.T) {
 		output   string
 	}{
 		{
-			scenario: "Should print who can crete configmaps",
+			scenario: "Should print who can create configmaps",
 			args:     []string{"create", "cm"},
 			output: `ROLEBINDING                  NAMESPACE  SUBJECT  TYPE  SA-NAMESPACE
 alice-can-create-configmaps  default    Alice    User`,


### PR DESCRIPTION
A scaffold for integration tests against real Kubernetes API. The integration test runs two containers in docker compose: 1) K3S, i.e. lean Kubernetes cluster; 2) Test executable itself. Both containers share KUBECONFIG via `shared-data` volume and `KUBECONFIG` env.

It's also integrated with TravisCI, i.e. runs on each PR and merge to master.