### PR TITLE
fix: Match RoleBindings bound to ClusterRoles

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -35,3 +35,4 @@ changelog:
       - '^docs:'
       - '^test:'
       - '^chore:'
+      - '^refactor:'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,7 +3,7 @@ before:
     - go mod download
 builds:
   - # Path to main.go file or main package.
-    main: ./cmd/kubectl-who-can.go
+    main: ./cmd/kubectl-who-can/main.go
     # Custom environment variables to be set during the builds.
     env:
       - CGO_ENABLED=0

--- a/pkg/cmd/list_test.go
+++ b/pkg/cmd/list_test.go
@@ -577,14 +577,17 @@ func TestWhoCan_GetClusterRolesFor(t *testing.T) {
 func TestWhoCan_GetRoleBindings(t *testing.T) {
 	client := fake.NewSimpleClientset()
 
+	namespace := "foo"
 	roleNames := map[string]struct{}{"view-pods": {}}
+	clusterRoleNames := map[string]struct{}{"view-configmaps": {}}
 
 	viewPodsBnd := rbac.RoleBinding{
 		ObjectMeta: meta.ObjectMeta{
-			Name: "view-pods-bnd",
+			Name:      "view-pods-bnd",
+			Namespace: namespace,
 		},
 		RoleRef: rbac.RoleRef{
-			Kind: "RoleBinding",
+			Kind: "Role",
 			Name: "view-pods",
 		},
 	}
@@ -594,7 +597,7 @@ func TestWhoCan_GetRoleBindings(t *testing.T) {
 			Name: "view-configmaps-bnd",
 		},
 		RoleRef: rbac.RoleRef{
-			Kind: "RoleBinding",
+			Kind: "ClusterRole",
 			Name: "view-configmaps",
 		},
 	}
@@ -612,15 +615,17 @@ func TestWhoCan_GetRoleBindings(t *testing.T) {
 
 	wc := whoCan{
 		clientRBAC: client.RbacV1(),
+		Action:     Action{namespace: namespace},
 	}
 
 	// when
-	bindings, err := wc.GetRoleBindings(roleNames)
+	bindings, err := wc.GetRoleBindings(roleNames, clusterRoleNames)
 
 	// then
 	require.NoError(t, err)
-	assert.Equal(t, 1, len(bindings))
+	assert.Equal(t, 2, len(bindings))
 	assert.Contains(t, bindings, viewPodsBnd)
+	assert.Contains(t, bindings, viewConfigMapsBnd)
 }
 
 func TestWhoCan_GetClusterRoleBindings(t *testing.T) {

--- a/pkg/cmd/policy_rule_matcher_test.go
+++ b/pkg/cmd/policy_rule_matcher_test.go
@@ -1,0 +1,189 @@
+package cmd
+
+import (
+	"github.com/stretchr/testify/assert"
+	rbac "k8s.io/api/rbac/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+func TestMatcher_MatchesRole(t *testing.T) {
+	// given
+	matcher := NewPolicyRuleMatcher()
+	role := rbac.Role{
+		ObjectMeta: meta.ObjectMeta{Name: "view-services"},
+		Rules: []rbac.PolicyRule{
+			{
+				Verbs:     []string{"get", "list"},
+				Resources: []string{"services"},
+			},
+			{
+				Verbs:     []string{"get", "list"},
+				Resources: []string{"endpoints"},
+			},
+		},
+	}
+	action := Action{verb: "list", resource: "endpoints"}
+
+	// then
+	assert.True(t, matcher.MatchesRole(role, action))
+}
+
+func TestMatcher_MatchesClusterRole(t *testing.T) {
+	// given
+	matcher := NewPolicyRuleMatcher()
+	role := rbac.ClusterRole{
+		ObjectMeta: meta.ObjectMeta{Name: "edit-deployments"},
+		Rules: []rbac.PolicyRule{
+			{
+				Verbs:     []string{"update", "patch", "delete"},
+				Resources: []string{"deployments"},
+			},
+			{
+				Verbs:     []string{"update"},
+				Resources: []string{"deployments/scale"},
+			},
+		},
+	}
+	action := Action{verb: "update", resource: "deployments/scale"}
+
+	// then
+	assert.True(t, matcher.MatchesClusterRole(role, action))
+}
+
+func TestMatcher_matches(t *testing.T) {
+	data := []struct {
+		scenario string
+
+		rule   rbac.PolicyRule
+		action Action
+
+		matches bool
+	}{
+		{
+			scenario: "A",
+			action:   Action{verb: "get", resource: "services", resourceName: ""},
+			rule: rbac.PolicyRule{
+				Verbs:     []string{"get", "list"},
+				Resources: []string{"services"},
+			},
+			matches: true,
+		},
+		{
+			scenario: "B",
+			action:   Action{verb: "get", resource: "services", resourceName: ""},
+			rule: rbac.PolicyRule{
+				Verbs:     []string{"get", "list"},
+				Resources: []string{"*"},
+			},
+			matches: true,
+		},
+		{
+			scenario: "C",
+			action:   Action{verb: "get", resource: "services", resourceName: ""},
+			rule: rbac.PolicyRule{
+				Verbs:     []string{"*"},
+				Resources: []string{"services"},
+			},
+			matches: true,
+		},
+		{
+			scenario: "D",
+			action:   Action{verb: "get", resource: "services", resourceName: "mongodb"},
+			rule: rbac.PolicyRule{
+				Verbs:     []string{"get", "list"},
+				Resources: []string{"services"},
+			},
+			matches: true,
+		},
+		{
+			scenario: "E",
+			action:   Action{verb: "get", resource: "services", resourceName: "mongodb"},
+			rule: rbac.PolicyRule{
+				Verbs:         []string{"get", "list"},
+				Resources:     []string{"services"},
+				ResourceNames: []string{"mongodb", "nginx"},
+			},
+			matches: true,
+		},
+		{
+			scenario: "F",
+			action:   Action{verb: "get", resource: "services", resourceName: "mongodb"},
+			rule: rbac.PolicyRule{
+				Verbs:         []string{"get", "list"},
+				Resources:     []string{"services"},
+				ResourceNames: []string{"nginx"},
+			},
+			matches: false,
+		},
+		{
+			scenario: "G",
+			action:   Action{verb: "get", resource: "services", resourceName: ""},
+			rule: rbac.PolicyRule{
+				Verbs:         []string{"get", "list"},
+				Resources:     []string{"services"},
+				ResourceNames: []string{"nginx"},
+			},
+			matches: false,
+		},
+		{
+			scenario: "H",
+			action:   Action{verb: "get", resource: "pods", resourceName: ""},
+			rule: rbac.PolicyRule{
+				Verbs:     []string{"create"},
+				Resources: []string{"pods"},
+			},
+			matches: false,
+		},
+		{
+			scenario: "I",
+			action:   Action{verb: "get", resource: "persistentvolumes", resourceName: ""},
+			rule: rbac.PolicyRule{
+				Verbs:     []string{"get"},
+				Resources: []string{"pods"},
+			},
+			matches: false,
+		},
+		{
+			scenario: "J",
+			action:   Action{verb: "get", nonResourceURL: "/logs"},
+			rule: rbac.PolicyRule{
+				Verbs:           []string{"get"},
+				NonResourceURLs: []string{"/logs"},
+			},
+			matches: true,
+		},
+		{
+			scenario: "K",
+			action:   Action{verb: "get", nonResourceURL: "/logs"},
+			rule: rbac.PolicyRule{
+				Verbs:           []string{"post"},
+				NonResourceURLs: []string{"/logs"},
+			},
+			matches: false,
+		},
+		{
+			scenario: "L",
+			action:   Action{verb: "get", nonResourceURL: "/logs"},
+			rule: rbac.PolicyRule{
+				Verbs:           []string{"get"},
+				NonResourceURLs: []string{"/api"},
+			},
+			matches: false,
+		},
+	}
+
+	// given
+	policyRuleMatcher := matcher{}
+
+	for _, tt := range data {
+		t.Run(tt.scenario, func(t *testing.T) {
+			// when
+			matches := policyRuleMatcher.matches(tt.rule, tt.action)
+
+			// then
+			assert.Equal(t, tt.matches, matches)
+		})
+	}
+
+}


### PR DESCRIPTION
This one is supposed to resolve #31 . I took also the opportunity to refactor and add more unit tests to the functionality of mapping [Cluster]RoleBindings to [Cluster]Roles.
At the end I've added the scenario to our integration test suite which reproduced the actual issue reported by @raesene

I suggest review this PR commit by commit.