### PR TITLE
Allow cmd package to be used as Golang module

### DIFF
--- a/cmd/kubectl-who-can/main.go
+++ b/cmd/kubectl-who-can/main.go
@@ -10,7 +10,7 @@ import (
 )
 
 func main() {
-	root, err := cmd.NewCmdWhoCan(clioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr})
+	root, err := cmd.NewWhoCanCommand(clioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr})
 	if err != nil {
 		fmt.Printf("Error: %v\n", err)
 		os.Exit(1)

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.12
 require (
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/spf13/cobra v0.0.4
+	github.com/spf13/pflag v1.0.3
 	github.com/stretchr/testify v1.3.0
 	k8s.io/api v0.0.0-20190703205437-39734b2a72fe
 	k8s.io/apiextensions-apiserver v0.0.0-20190704050600-357b4270afe4

--- a/go.sum
+++ b/go.sum
@@ -139,9 +139,11 @@ github.com/json-iterator/go v0.0.0-20180701071628-ab8a2e0c74be/go.mod h1:+SdeFBv
 github.com/json-iterator/go v1.1.6 h1:MrUvLMLTMxbqFJ9kzlvat/rYZqZnW3u4wkLzWTaFwKs=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mailru/easyjson v0.0.0-20180823135443-60711f1a8329 h1:2gxZ0XQIU/5z3Z3bUBu+FXuk2pFbkN6tcwi/pjyaDic=
@@ -160,9 +162,11 @@ github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8m
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/onsi/ginkgo v1.6.0 h1:Ix8l273rp3QzYgXSR+c8d1fTG7UPgYkOSELPhiY/YGw=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
+github.com/onsi/ginkgo v1.8.0 h1:VkHVNpR4iVnU8XQR6DBm8BqYjN7CRzw+xKUbVVbbW9w=
 github.com/onsi/ginkgo v1.8.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v0.0.0-20190113212917-5533ce8a0da3 h1:EooPXg51Tn+xmWPXJUGCnJhJSpeuMlBmfJVcqIRmmv8=
 github.com/onsi/gomega v0.0.0-20190113212917-5533ce8a0da3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
+github.com/onsi/gomega v1.5.0 h1:izbySO9zDPmjJ8rDjLvkA2zJHIo+HkYXHnf7eN7SSyo=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
@@ -239,6 +243,7 @@ golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4 h1:YUO/7uOKsKeq9UokNS62b8FYywz3ker1l1vDZRCRefw=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -274,6 +279,7 @@ google.golang.org/genproto v0.0.0-20170731182057-09f6ed296fc6/go.mod h1:JiN7NxoA
 google.golang.org/grpc v1.13.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=

--- a/pkg/cmd/list_test.go
+++ b/pkg/cmd/list_test.go
@@ -219,7 +219,7 @@ func TestComplete(t *testing.T) {
 			}
 
 			// given
-			o := whoCan{
+			o := WhoCan{
 				Action: Action{
 					namespace:     tt.flags.namespace,
 					allNamespaces: tt.flags.allNamespaces,
@@ -297,7 +297,7 @@ func TestValidate(t *testing.T) {
 					Return(tt.namespaceValidation.returnedError)
 			}
 
-			o := &whoCan{
+			o := &WhoCan{
 				Action: Action{
 					nonResourceURL: tt.nonResourceURL,
 					subResource:    tt.subResource,
@@ -400,7 +400,7 @@ func TestWhoCan_checkAPIAccess(t *testing.T) {
 
 			// given
 			configFlags := &clioptions.ConfigFlags{}
-			wc := whoCan{
+			wc := WhoCan{
 				Action: Action{
 					namespace: tt.namespace,
 				},
@@ -455,7 +455,7 @@ func TestWhoCan_printAPIAccessWarnings(t *testing.T) {
 	for _, tt := range data {
 		t.Run(tt.scenario, func(t *testing.T) {
 			var buf bytes.Buffer
-			wc := whoCan{}
+			wc := WhoCan{}
 			wc.Out = &buf
 			wc.printAPIAccessWarnings(tt.warnings)
 			assert.Equal(t, tt.expectedOutput, buf.String())
@@ -508,7 +508,7 @@ func TestWhoCan_GetRolesFor(t *testing.T) {
 	policyRuleMatcher.On("MatchesRole", viewServicesRole, action).Return(true)
 	policyRuleMatcher.On("MatchesRole", viewPodsRole, action).Return(false)
 
-	wc := whoCan{
+	wc := WhoCan{
 		clientRBAC:        client.RbacV1(),
 		policyRuleMatcher: policyRuleMatcher,
 	}
@@ -567,7 +567,7 @@ func TestWhoCan_GetClusterRolesFor(t *testing.T) {
 	policyRuleMatcher.On("MatchesClusterRole", getLogsRole, action).Return(false)
 	policyRuleMatcher.On("MatchesClusterRole", getApiRole, action).Return(true)
 
-	wc := whoCan{
+	wc := WhoCan{
 		clientRBAC:        client.RbacV1(),
 		policyRuleMatcher: policyRuleMatcher,
 	}
@@ -620,7 +620,7 @@ func TestWhoCan_GetRoleBindings(t *testing.T) {
 		return true, list, nil
 	})
 
-	wc := whoCan{
+	wc := WhoCan{
 		clientRBAC: client.RbacV1(),
 		Action:     Action{namespace: namespace},
 	}
@@ -671,7 +671,7 @@ func TestWhoCan_GetClusterRoleBindings(t *testing.T) {
 		return true, list, nil
 	})
 
-	wc := whoCan{
+	wc := WhoCan{
 		clientRBAC: client.RbacV1(),
 	}
 
@@ -758,7 +758,7 @@ Bob-and-Eve-can-view-pods  Eve      User
 		t.Run(tt.scenario, func(t *testing.T) {
 			// given
 			streams, _, out, _ := clioptions.NewTestIOStreams()
-			wc := whoCan{
+			wc := WhoCan{
 				Action: Action{
 					verb:           tt.verb,
 					resource:       tt.resource,

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -92,7 +92,7 @@ func TestIntegration(t *testing.T) {
 	for _, tt := range data {
 		t.Run(tt.scenario, func(t *testing.T) {
 			streams, _, out, _ := clioptions.NewTestIOStreams()
-			root, err := cmd.NewCmdWhoCan(streams)
+			root, err := cmd.NewWhoCanCommand(streams)
 			require.NoError(t, err)
 
 			root.SetArgs(tt.args)


### PR DESCRIPTION
This introduces a number of changes to enable the `WhoCan` type to be
used in external projects. The `WhoCan` type is exported, and functions
are introduced to allow instances of `WhoCan` and `Action` to be
created. It also modifies the `Check` function to no longer call
`output` to display the results. Instead, `Check` returns the role
bindings that enable an action to be performed. The call to `output` now
takes place in the run function for the command.

Overall, this results in no functional changes to the `kubectl-who-can`
program, but allows it to be imported and used from other projects.

Signed-off-by: Bridget McErlean <bmcerlean@vmware.com>