### PR TITLE
Use REST config instead of ClientConfig

### DIFF
--- a/pkg/cmd/list_test.go
+++ b/pkg/cmd/list_test.go
@@ -11,7 +11,6 @@ import (
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	clioptions "k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/kubernetes/fake"
 	clientTesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/clientcmd"
@@ -334,9 +333,7 @@ func TestWhoCan_CheckAPIAccess(t *testing.T) {
 			}
 
 			// given
-			configFlags := &clioptions.ConfigFlags{}
 			wc := WhoCan{
-				clientConfig:       configFlags.ToRawKubeConfigLoader(),
 				clientNamespace:    client.CoreV1().Namespaces(),
 				clientRBAC:         client.RbacV1(),
 				namespaceValidator: namespaceValidator,


### PR DESCRIPTION
This updates the `NewWhoCan` method to take a `rest.Config` object
instead of a `ClientConfig` object. This allows the consumer of the API
to use a custom `rest.Config` object rather than relying on the one
created from the `ClientConfig` object.

This also removes the `clientConfig` field from the `WhoCan` object. It
is only used within the `ActionFrom` method, and it is passed in as an
argument. As a result, there is no need to store it on the `WhoCan`
object.

Signed-off-by: Bridget McErlean <bmcerlean@vmware.com>